### PR TITLE
Rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "snip_lookup_rust"
+name = "snip_lookup"
 version = "0.1.0"
 dependencies = [
  "nvim-oxi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "snip_lookup_rust"
+name = "snip_lookup"
 version = "0.1.0"
 edition = "2021"
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,3 @@
 #!/bin/bash
 
-cargo build --release
-
-cp target/release/libsnip_lookup.dylib lua/snip_lookup.so
-cp lua/snip_lookup.so lua/snip_lookup.dll
+cargo build --all --release && mv target/release/libsnip_lookup.dylib lua/snip_lookup.so

--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,5 @@
 
 cargo build --release
 
-cp target/release/libsnip_lookup_rust.dylib lua/snip_lookup_rust.so
-cp lua/snip_lookup_rust.so lua/snip_lookup_rust.dll
+cp target/release/libsnip_lookup.dylib lua/snip_lookup.so
+cp lua/snip_lookup.so lua/snip_lookup.dll

--- a/lua/snip-lookup/init.lua
+++ b/lua/snip-lookup/init.lua
@@ -46,6 +46,8 @@ M.setup = function(opts)
     -- TODO: need to error if user tries to pass an option that doesn't exist
     if opts ~= nil then
         config.opts = vim.tbl_deep_extend('keep', opts, config.default_opts)
+    else
+        config.opts = config.default_opts
     end
 
     vim.api.nvim_set_keymap(

--- a/lua/snip-lookup/init.lua
+++ b/lua/snip-lookup/init.lua
@@ -8,7 +8,7 @@ local conf = require('telescope.config').values
 local actions = require 'telescope.actions'
 local action_state = require 'telescope.actions.state'
 -- Rust
-local rust = require 'snip_lookup_rust'
+local rust = require 'snip_lookup'
 -- snip-lookup stuff
 local config = require 'snip-lookup.config'
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl SnippetConfig {
 }
 
 #[oxi::module]
-fn snip_lookup_rust() -> oxi::Result<Dictionary> {
+fn snip_lookup() -> oxi::Result<Dictionary> {
     let get_categories = Function::from_fn::<_, oxi::Error>(move |path: String| {
         let mut category_names: HashMap<String, String> = HashMap::new();
 


### PR DESCRIPTION
Remove rust suffix from rust lib and use default config if none is provided to setup function