### PR TITLE
Fix/icons

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,10 @@ fn snip_lookup() -> oxi::Result<Dictionary> {
             );
         }
 
+        for icon in category_names.values_mut() {
+            *icon = format!("{:>width$}", *icon, width = longest_icon);
+        }
+
         let nvim_categories = NeovimWrapper {
             contents: category_names,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,20 +82,21 @@ fn snip_lookup() -> oxi::Result<Dictionary> {
         let mut category_names: HashMap<String, String> = HashMap::new();
 
         let sc = SnippetConfig::load(path).unwrap();
-        let mut longest_icon = 0; // Used for padding each icon to the same width
+        let mut longest_icon_length = 0; // Used for padding each icon to the same width
         for (category_name, category_contents) in sc.categories.into_iter() {
-            if category_contents.icon.len() > longest_icon {
-                longest_icon = category_contents.icon.len();
+            let icon_length = category_contents.icon.chars().count();
+            if icon_length > longest_icon_length {
+                longest_icon_length = icon_length;
             }
-            oxi::print!("longest_icon width = {}", &longest_icon);
             category_names.insert(
                 category_name.to_string(),
                 category_contents.icon.to_string(),
             );
         }
 
+        // Pad each icon so that category names all begin at same column
         for icon in category_names.values_mut() {
-            *icon = format!("{:>width$}", *icon, width = longest_icon);
+            *icon = format!("{:width$}", *icon, width = longest_icon_length);
         }
 
         let nvim_categories = NeovimWrapper {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,12 @@ fn snip_lookup() -> oxi::Result<Dictionary> {
         let mut category_names: HashMap<String, String> = HashMap::new();
 
         let sc = SnippetConfig::load(path).unwrap();
+        let mut longest_icon = 0; // Used for padding each icon to the same width
         for (category_name, category_contents) in sc.categories.into_iter() {
+            if category_contents.icon.len() > longest_icon {
+                longest_icon = category_contents.icon.len();
+            }
+            oxi::print!("longest_icon width = {}", &longest_icon);
             category_names.insert(
                 category_name.to_string(),
                 category_contents.icon.to_string(),


### PR DESCRIPTION
This was originally intended to resolve issues where certain emojis display as wider than others, causing the category names to not all start on the same column... but instead this only works for non-emoji icons (setting the icon yaml key to a word, etc.). Will revisit in the future